### PR TITLE
used updated Playwright error module in import

### DIFF
--- a/tiktok_hashtag_analysis/base.py
+++ b/tiktok_hashtag_analysis/base.py
@@ -23,7 +23,7 @@ from tenacity import (
     TryAgain,
     wait_exponential,
 )
-from playwright._impl._api_types import Error
+from playwright._impl._errors import Error
 from TikTokApi import TikTokApi
 
 

--- a/tiktok_hashtag_analysis/version.py
+++ b/tiktok_hashtag_analysis/version.py
@@ -2,7 +2,7 @@ _MAJOR = "2"
 _MINOR = "0"
 # On main and in a nightly release the patch should be one ahead of the last
 # released build.
-_PATCH = "2"
+_PATCH = "3"
 # This is mainly for nightly builds which have the suffix ".dev$DATE". See
 # https://semver.org/#is-v123-a-semantic-version for the semantics.
 _SUFFIX = ""


### PR DESCRIPTION
Should fix error from this comment https://github.com/bellingcat/tiktok-hashtag-analysis/issues/21#issuecomment-1846168357

Playwright apparently reorganized its `_impl` subpackage and moved the `Error` class from the `_api_types.py` module to the `_errors.py` module. 