### PR TITLE
Reduce video limit to avoid error

### DIFF
--- a/tiktok_hashtag_analysis/cli.py
+++ b/tiktok_hashtag_analysis/cli.py
@@ -69,7 +69,7 @@ def create_parser():
         "--limit",
         type=int,
         help="Maximum number of videos to download for each hashtag",
-        default=1000,
+        default=35,
     )
     parser.add_argument(
         "-v",

--- a/tiktok_hashtag_analysis/version.py
+++ b/tiktok_hashtag_analysis/version.py
@@ -2,7 +2,7 @@ _MAJOR = "2"
 _MINOR = "0"
 # On main and in a nightly release the patch should be one ahead of the last
 # released build.
-_PATCH = "3"
+_PATCH = "4"
 # This is mainly for nightly builds which have the suffix ".dev$DATE". See
 # https://semver.org/#is-v123-a-semantic-version for the semantics.
 _SUFFIX = ""


### PR DESCRIPTION
Closes #28

It looks like a change to the TikTok API limits the number of videos to 35, this drops the default --limit CLI to 35 to avoid causing the error.